### PR TITLE
put blocking opps in get online features in threadpool

### DIFF
--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -78,7 +78,6 @@ class GetOnlineFeaturesRequest(BaseModel):
 def _get_features(
     request: GetOnlineFeaturesRequest, store: "feast.FeatureStore"
 ) -> list[str] | FeatureService:
-    # Initialize parameters for FeatureStore.get_online_features(...) call
     if request.feature_service:
         feature_service = store.get_feature_service(
             request.feature_service, allow_cache=True
@@ -154,6 +153,7 @@ def get_app(
         dependencies=[Depends(inject_user_details)],
     )
     async def get_online_features(request: GetOnlineFeaturesRequest) -> Dict[str, Any]:
+        # Initialize parameters for FeatureStore.get_online_features(...) call
         features = await run_in_threadpool(_get_features, request, store)
 
         read_params = dict(

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -17,7 +17,7 @@ from prometheus_client import Gauge, start_http_server
 from pydantic import BaseModel
 
 import feast
-from feast import proto_json, utils, FeatureService
+from feast import proto_json, utils
 from feast.constants import DEFAULT_FEATURE_SERVER_REGISTRY_TTL
 from feast.data_source import PushMode
 from feast.errors import (
@@ -77,7 +77,7 @@ class GetOnlineFeaturesRequest(BaseModel):
 
 def _get_features(
     request: GetOnlineFeaturesRequest, store: "feast.FeatureStore"
-) -> list[str] | FeatureService:
+) -> list[str] | "feast.FeatureService":
     if request.feature_service:
         feature_service = store.get_feature_service(
             request.feature_service, allow_cache=True

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -75,9 +75,7 @@ class GetOnlineFeaturesRequest(BaseModel):
     full_feature_names: bool = False
 
 
-def _get_features(
-    request: GetOnlineFeaturesRequest, store: "feast.FeatureStore"
-) -> list[str] | "feast.FeatureService":
+def _get_features(request: GetOnlineFeaturesRequest, store: "feast.FeatureStore"):
     if request.feature_service:
         feature_service = store.get_feature_service(
             request.feature_service, allow_cache=True

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -17,7 +17,7 @@ from prometheus_client import Gauge, start_http_server
 from pydantic import BaseModel
 
 import feast
-from feast import proto_json, utils
+from feast import proto_json, utils, FeatureService
 from feast.constants import DEFAULT_FEATURE_SERVER_REGISTRY_TTL
 from feast.data_source import PushMode
 from feast.errors import (
@@ -75,6 +75,41 @@ class GetOnlineFeaturesRequest(BaseModel):
     full_feature_names: bool = False
 
 
+def _get_features(
+    request: GetOnlineFeaturesRequest, store: "feast.FeatureStore"
+) -> list[str] | FeatureService:
+    # Initialize parameters for FeatureStore.get_online_features(...) call
+    if request.feature_service:
+        feature_service = store.get_feature_service(
+            request.feature_service, allow_cache=True
+        )
+        assert_permissions(
+            resource=feature_service, actions=[AuthzedAction.READ_ONLINE]
+        )
+        features = feature_service  # type: ignore
+    else:
+        all_feature_views, all_on_demand_feature_views = (
+            utils._get_feature_views_to_use(
+                store.registry,
+                store.project,
+                request.features,
+                allow_cache=True,
+                hide_dummy_entity=False,
+            )
+        )
+        for feature_view in all_feature_views:
+            assert_permissions(
+                resource=feature_view, actions=[AuthzedAction.READ_ONLINE]
+            )
+        for od_feature_view in all_on_demand_feature_views:
+            assert_permissions(
+                resource=od_feature_view, actions=[AuthzedAction.READ_ONLINE]
+            )
+        features = request.features  # type: ignore
+
+    return features
+
+
 def get_app(
     store: "feast.FeatureStore",
     registry_ttl_sec: int = DEFAULT_FEATURE_SERVER_REGISTRY_TTL,
@@ -119,34 +154,7 @@ def get_app(
         dependencies=[Depends(inject_user_details)],
     )
     async def get_online_features(request: GetOnlineFeaturesRequest) -> Dict[str, Any]:
-        # Initialize parameters for FeatureStore.get_online_features(...) call
-        if request.feature_service:
-            feature_service = store.get_feature_service(
-                request.feature_service, allow_cache=True
-            )
-            assert_permissions(
-                resource=feature_service, actions=[AuthzedAction.READ_ONLINE]
-            )
-            features = feature_service  # type: ignore
-        else:
-            all_feature_views, all_on_demand_feature_views = (
-                utils._get_feature_views_to_use(
-                    store.registry,
-                    store.project,
-                    request.features,
-                    allow_cache=True,
-                    hide_dummy_entity=False,
-                )
-            )
-            for feature_view in all_feature_views:
-                assert_permissions(
-                    resource=feature_view, actions=[AuthzedAction.READ_ONLINE]
-                )
-            for od_feature_view in all_on_demand_feature_views:
-                assert_permissions(
-                    resource=od_feature_view, actions=[AuthzedAction.READ_ONLINE]
-                )
-            features = request.features  # type: ignore
+        features = await run_in_threadpool(_get_features, request, store)
 
         read_params = dict(
             features=features,
@@ -162,9 +170,13 @@ def get_app(
             )
 
         # Convert the Protobuf object to JSON and return it
-        return MessageToDict(
-            response.proto, preserving_proto_field_name=True, float_precision=18
+        response_dict = await run_in_threadpool(
+            MessageToDict,
+            response.proto,
+            preserving_proto_field_name=True,
+            float_precision=18,
         )
+        return response_dict
 
     @app.post("/push", dependencies=[Depends(inject_user_details)])
     async def push(request: PushFeaturesRequest) -> None:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

* see issue #4887 describing a performance regression due to the blocking operations in the /get-online-features async path operation
* put the feature collection and response serialization in thread pool

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #4887

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
